### PR TITLE
fix(simplenotes): set canonical description and remove debug print

### DIFF
--- a/apps/simplenotes/forms.py
+++ b/apps/simplenotes/forms.py
@@ -54,8 +54,6 @@ class SimpleNoteForm(forms.ModelForm):
             )
             self.fields["event_datetime"].initial = dt.strftime("%Y-%m-%dT%H:%M")
 
-        print(self.fields["event_datetime"].initial)
-
         # Configure field properties
         self.fields[
             "content"
@@ -78,10 +76,10 @@ class SimpleNoteForm(forms.ModelForm):
         return content
 
     def save(self, commit=True):
-        """Override save to set created_by and updated_by fields."""
+        """Override save to set canonical description and audit fields."""
         instance = super().save(commit=False)
+        instance.description = Event.EVENT_TYPE_CHOICES[Event.SIMPLE_NOTE_EVENT][1]
 
-        self.description = Event.EVENT_TYPE_CHOICES[Event.SIMPLE_NOTE_EVENT][1]
         if self.user:
             if not instance.pk:  # New instance
                 instance.created_by = self.user

--- a/apps/simplenotes/models.py
+++ b/apps/simplenotes/models.py
@@ -7,7 +7,7 @@ class SimpleNote(Event):
     Simple Note model that extends the base Event model.
     Used for day-to-day patient management observations and notes.
     """
-    content = models.TextField(verbose_name="Conteúdo")
+    content: models.TextField = models.TextField(verbose_name="Conteúdo")
 
     def save(self, *args, **kwargs):
         """Override save to set the correct event type."""

--- a/apps/simplenotes/tests/test_models_forms.py
+++ b/apps/simplenotes/tests/test_models_forms.py
@@ -1,6 +1,11 @@
+import io
+from contextlib import redirect_stdout
+
 from django.test import TestCase
 from django.contrib.auth import get_user_model
 from django.utils import timezone
+
+from apps.events.models import Event
 from apps.patients.models import Patient
 from ..models import SimpleNote
 from ..forms import SimpleNoteForm
@@ -14,6 +19,7 @@ class SimpleNoteModelTests(TestCase):
     def setUp(self):
         """Set up test data."""
         self.user = User.objects.create_user(
+            username="simplenote-model-user",
             email="test@example.com",
             password="testpass123",
             first_name="Test",
@@ -88,6 +94,7 @@ class SimpleNoteFormTests(TestCase):
     def setUp(self):
         """Set up test data."""
         self.user = User.objects.create_user(
+            username="simplenote-form-user",
             email="test@example.com",
             password="testpass123",
             first_name="Test",
@@ -132,20 +139,29 @@ class SimpleNoteFormTests(TestCase):
         self.assertFalse(form.is_valid())
         self.assertIn('event_datetime', form.errors)
 
-    def test_form_save(self):
-        """Test form save functionality."""
+    def test_form_save_sets_canonical_description(self):
+        """Form save should persist canonical simple note description."""
         form_data = {
-            'event_datetime': timezone.now(),
-            'content': 'This is a valid simple note content for testing save functionality.'
+            "event_datetime": timezone.now(),
+            "content": "This is a valid simple note content for testing save functionality.",
         }
         form = SimpleNoteForm(data=form_data, user=self.user)
         self.assertTrue(form.is_valid())
-        
-        # Test creating new instance
+
         simple_note = form.save(commit=False)
         simple_note.patient = self.patient
-        simple_note.description = "Nota/Observação"
         simple_note.save()
-        
+
+        expected_description = Event.EVENT_TYPE_CHOICES[Event.SIMPLE_NOTE_EVENT][1]
+        self.assertEqual(simple_note.description, expected_description)
         self.assertEqual(simple_note.created_by, self.user)
         self.assertEqual(simple_note.updated_by, self.user)
+
+    def test_form_init_has_no_debug_stdout(self):
+        """Form initialization should not print debug output."""
+        output_buffer = io.StringIO()
+
+        with redirect_stdout(output_buffer):
+            SimpleNoteForm(user=self.user)
+
+        self.assertEqual(output_buffer.getvalue(), "")

--- a/openspec/changes/week1-simplenotes-pilot/slices/slice-01-prompt.md
+++ b/openspec/changes/week1-simplenotes-pilot/slices/slice-01-prompt.md
@@ -9,24 +9,24 @@ Rules:
 
 Checklist:
 Spec
-- [ ] requirements understood
+- [x] requirements understood
 
 Tests (RED)
-- [ ] failing tests written
-- [ ] tests cover behavior and edge cases
+- [x] failing tests written
+- [x] tests cover behavior and edge cases
 
 Implementation (GREEN)
-- [ ] minimal code added
-- [ ] tests pass
+- [x] minimal code added
+- [x] tests pass
 
 Refactor (CLEAN)
-- [ ] responsibilities separated
-- [ ] duplication removed
-- [ ] functions small
-- [ ] naming improved
+- [x] responsibilities separated
+- [x] duplication removed
+- [x] functions small
+- [x] naming improved
 
 Verification
-- [ ] verification command passes
+- [x] verification command passes
 
 STOP RULE
-- [ ] stop here and do NOT start next slice
+- [x] stop here and do NOT start next slice

--- a/openspec/changes/week1-simplenotes-pilot/tasks.md
+++ b/openspec/changes/week1-simplenotes-pilot/tasks.md
@@ -1,15 +1,15 @@
 ## 1. Preparação do piloto (OpenSpec + escopo)
 
-- [ ] 1.1 Validar escopo exato do piloto (sem scope creep)
-- [ ] 1.2 Confirmar arquivos-alvo do slice 1
-- [ ] 1.3 Confirmar comandos de verificação (test/typecheck)
+- [x] 1.1 Validar escopo exato do piloto (sem scope creep)
+- [x] 1.2 Confirmar arquivos-alvo do slice 1
+- [x] 1.3 Confirmar comandos de verificação (test/typecheck)
 
 ## 2. Slice 1 — Form hardening (bugfix + limpeza)
 
-- [ ] 2.1 Escrever testes RED para descrição padrão no `SimpleNoteForm.save()`
-- [ ] 2.2 Corrigir persistência da descrição padrão
-- [ ] 2.3 Remover `print` de debug do form
-- [ ] 2.4 Validar `./scripts/test.sh apps.simplenotes`
+- [x] 2.1 Escrever testes RED para descrição padrão no `SimpleNoteForm.save()`
+- [x] 2.2 Corrigir persistência da descrição padrão
+- [x] 2.3 Remover `print` de debug do form
+- [x] 2.4 Validar `./scripts/test.sh apps.simplenotes`
 
 ## 3. Slice 2 — CRUD safety net mínimo
 

--- a/scripts/install-dev-deps.sh
+++ b/scripts/install-dev-deps.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env sh
-set -eu
+#!/usr/bin/env bash
+set -euo pipefail
 
-docker compose exec --user root eqmd-dev uv pip install --system --group dev
+DOCKER_SERVICE="${EQMD_DOCKER_SERVICE:-eqmd_dev}"
+
+exec docker exec --user root "${DOCKER_SERVICE}" sh -lc 'cd /app && uv pip install --system --group dev'

--- a/scripts/typecheck.sh
+++ b/scripts/typecheck.sh
@@ -20,4 +20,9 @@ if [[ $# -eq 0 ]]; then
   exit 2
 fi
 
+if ! docker exec "${DOCKER_SERVICE}" sh -lc 'command -v mypy >/dev/null 2>&1'; then
+  echo "[typecheck] mypy not found in ${DOCKER_SERVICE}. Installing dev dependencies..."
+  docker exec --user root "${DOCKER_SERVICE}" sh -lc 'cd /app && uv pip install --system --group dev'
+fi
+
 exec docker exec "${DOCKER_SERVICE}" mypy "$@"


### PR DESCRIPTION
fix(simplenotes): set canonical description and remove debug print

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unintended debug output during form initialization
  * Corrected form save to properly assign the canonical description value

* **Tests**
  * Enhanced form test setup with explicit user identifiers
  * Added verification that form initialization produces no debug output

* **Chores**
  * Updated pilot project status checkpoints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->