### PR TITLE
docs(openspec): close week1 simplenotes pilot slice 03

### DIFF
--- a/docs/workflows/devloop-migration/progress-log.md
+++ b/docs/workflows/devloop-migration/progress-log.md
@@ -71,3 +71,37 @@ Registro contínuo de evolução da migração de workflow no `eqmd`.
 
 ### Riscos/Bloqueios
 - Necessidade de calibrar duração do smoke v1 e estabilidade dos testes por app.
+
+---
+
+## 2026-03-22 — Semana 1 (piloto simplenotes concluído em slices)
+
+### Fase
+- 0–30 dias (Fundação + Piloto)
+
+### Concluído
+- Slice 01: hardening de `SimpleNoteForm` (descrição canônica + remoção de debug print).
+- Slice 02: safety net mínimo de views CRUD em `simplenotes`.
+- Slice 03: fechamento operacional (validação final + atualização de artefatos).
+- CI ajustado para rodar módulos de teste alterados antes de fallback por app.
+
+### Evidências
+- PR(s):
+  - #11 (`feat/week1-simplenotes-slice-01`)
+  - #12 (`feat/week1-simplenotes-slice-02`)
+  - Slice 03: branch `feat/week1-simplenotes-slice-03`
+- OpenSpec:
+  - `openspec/changes/week1-simplenotes-pilot/tasks.md`
+  - `openspec/changes/week1-simplenotes-pilot/slices/slice-03-prompt.md`
+
+### Métricas da semana
+- PRs com check obrigatório verde: #11 e #12
+- Falhas de smoke: corrigidas via estabilização de testes core e escopo de testes alterados no CI
+- Mudanças com OpenSpec completo: piloto `week1-simplenotes-pilot` com proposal/design/spec/tasks/slices
+
+### Próxima semana
+- Sincronizar/arquivar o change OpenSpec do piloto após merge do slice 3.
+- Iniciar próxima melhoria incremental no app de baixo risco (seguindo mesma disciplina).
+
+### Riscos/Bloqueios
+- Suite completa continua informativa e ainda possui falhas legadas fora do escopo do piloto.

--- a/openspec/changes/week1-simplenotes-pilot/slices/slice-03-prompt.md
+++ b/openspec/changes/week1-simplenotes-pilot/slices/slice-03-prompt.md
@@ -7,15 +7,15 @@ Rules:
 
 Checklist:
 Spec
-- [ ] requirements understood
+- [x] requirements understood
 
 Execution
-- [ ] validation commands executed
-- [ ] progress log updated
-- [ ] OpenSpec tasks updated
+- [x] validation commands executed
+- [x] progress log updated
+- [x] OpenSpec tasks updated
 
 Verification
-- [ ] verification commands pass
+- [x] verification commands pass
 
 STOP RULE
-- [ ] stop here and do NOT start next slice
+- [x] stop here and do NOT start next slice

--- a/openspec/changes/week1-simplenotes-pilot/tasks.md
+++ b/openspec/changes/week1-simplenotes-pilot/tasks.md
@@ -19,7 +19,7 @@
 
 ## 4. Slice 3 — Fechamento da semana 1
 
-- [ ] 4.1 Rodar typecheck escopado (`./scripts/typecheck.sh apps/simplenotes`)
-- [ ] 4.2 Atualizar `docs/workflows/devloop-migration/progress-log.md`
-- [ ] 4.3 Registrar evidências do piloto no PR
-- [ ] 4.4 Arquivar/sincronizar change OpenSpec ao concluir piloto
+- [x] 4.1 Rodar typecheck escopado (`./scripts/typecheck.sh apps/simplenotes`)
+- [x] 4.2 Atualizar `docs/workflows/devloop-migration/progress-log.md`
+- [x] 4.3 Registrar evidências do piloto no PR
+- [ ] 4.4 Arquivar/sincronizar change OpenSpec ao concluir piloto (pendente pós-merge do slice 3)


### PR DESCRIPTION
## Contexto
Fechamento do Slice 03 do change `week1-simplenotes-pilot` (sem novas features), com foco em validação final e atualização de artefatos de evidência.

## O que foi feito
- atualização de tarefas OpenSpec com status do slice 3
- checklist do prompt do slice 3 marcado como concluído
- atualização do `progress-log.md` com evidências da semana 1 (slices 01–03)

## Verificações executadas
- `./scripts/test.sh apps.simplenotes` ✅
- `./scripts/typecheck.sh apps/simplenotes` ✅

## Arquivos alterados
- `openspec/changes/week1-simplenotes-pilot/tasks.md`
- `openspec/changes/week1-simplenotes-pilot/slices/slice-03-prompt.md`
- `docs/workflows/devloop-migration/progress-log.md`

## Observação
- `4.4 Arquivar/sincronizar change OpenSpec` permanece pendente para o pós-merge deste slice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project progress tracking with completion details for week 1 of the simplenotes pilot program.
  * Documented outcomes from three completed development slices, including validation results and next-week priorities.
  * Marked corresponding checklist items as completed to reflect current project status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->