### PR TITLE
docs(openspec): add week2 historyandphysicals hardening change

### DIFF
--- a/docs/workflows/devloop-migration/progress-log.md
+++ b/docs/workflows/devloop-migration/progress-log.md
@@ -102,7 +102,7 @@ Registro contínuo de evolução da migração de workflow no `eqmd`.
 
 ### Próxima semana
 - Iniciar próxima melhoria incremental no app de baixo risco (seguindo a mesma disciplina DevLoop).
-- Change da semana 2 aberto: `openspec/changes/week2-historyandphysicals-hardening/`.
+- Definir candidato da semana 2 e abrir novo change OpenSpec.
 
 ### Riscos/Bloqueios
 - Suite completa continua informativa e ainda possui falhas legadas fora do escopo do piloto.

--- a/docs/workflows/devloop-migration/progress-log.md
+++ b/docs/workflows/devloop-migration/progress-log.md
@@ -102,7 +102,7 @@ Registro contínuo de evolução da migração de workflow no `eqmd`.
 
 ### Próxima semana
 - Iniciar próxima melhoria incremental no app de baixo risco (seguindo a mesma disciplina DevLoop).
-- Definir candidato da semana 2 e abrir novo change OpenSpec.
+- Change da semana 2 aberto: `openspec/changes/week2-historyandphysicals-hardening/`.
 
 ### Riscos/Bloqueios
 - Suite completa continua informativa e ainda possui falhas legadas fora do escopo do piloto.

--- a/openspec/changes/week2-historyandphysicals-hardening/design.md
+++ b/openspec/changes/week2-historyandphysicals-hardening/design.md
@@ -1,0 +1,47 @@
+## Context
+
+Este change aplica o mesmo padrão técnico-operacional validado no piloto da semana 1 (`simplenotes`) para o app `historyandphysicals`.
+
+Objetivo: fortalecer previsibilidade de comportamento no form e aumentar cobertura do fluxo essencial, mantendo escopo pequeno e risco controlado.
+
+## Goals / Non-Goals
+
+**Goals**
+- Garantir que o form persista a descrição canônica do evento (`HISTORY_AND_PHYSICAL_EVENT`).
+- Eliminar side effect de debug em inicialização de formulário.
+- Reforçar testes de fluxo essencial (create/update/delete) conforme regras atuais de permissão.
+- Executar o change em slices com TDD (RED/GREEN/REFACTOR).
+
+**Non-Goals**
+- Não reescrever arquitetura de views do app.
+- Não alterar política global de permissões do projeto.
+- Não introduzir novas features de produto.
+
+## Decisions
+
+1) **Descrição canônica no form**
+- **Decision:** manter e garantir a regra de descrição no `HistoryAndPhysicalForm.save()`.
+- **Rationale:** centraliza comportamento no ponto de persistência e reduz divergência entre views.
+
+2) **Sem debug stdout em produção/testes**
+- **Decision:** remover `print` do `__init__` do form.
+- **Rationale:** evitar ruído e side effects em testes/CI.
+
+3) **Cobertura de testes por risco real**
+- **Decision:** priorizar testes de create/update/delete e cenários mínimos de permissão.
+- **Rationale:** maior retorno com baixo risco na semana 2.
+
+## Risks / Trade-offs
+
+- **[Testes podem depender de comportamentos legados implícitos]** → Mitigação: explicitar expectativas com asserts diretos.
+- **[Escopo pode crescer para refator amplo]** → Mitigação: limitar mudanças aos arquivos do slice.
+
+## Verification Plan
+
+- `./scripts/test.sh apps.historyandphysicals`
+- `./scripts/typecheck.sh apps/historyandphysicals`
+
+## Rollback Plan
+
+- Reverter commits do change.
+- Reexecutar testes do app + typecheck escopado para confirmar restauração.

--- a/openspec/changes/week2-historyandphysicals-hardening/design.md
+++ b/openspec/changes/week2-historyandphysicals-hardening/design.md
@@ -1,40 +1,54 @@
 ## Context
 
-Este change aplica o mesmo padrão técnico-operacional validado no piloto da semana 1 (`simplenotes`) para o app `historyandphysicals`.
+Este change aplica o mesmo padrão técnico-operacional validado no piloto da
+semana 1 (`simplenotes`) para o app `historyandphysicals`.
 
-Objetivo: fortalecer previsibilidade de comportamento no form e aumentar cobertura do fluxo essencial, mantendo escopo pequeno e risco controlado.
+Objetivo: fortalecer previsibilidade de comportamento no form e aumentar
+cobertura do fluxo essencial, mantendo escopo pequeno e risco controlado.
 
 ## Goals / Non-Goals
 
 **Goals**
-- Garantir que o form persista a descrição canônica do evento (`HISTORY_AND_PHYSICAL_EVENT`).
-- Eliminar side effect de debug em inicialização de formulário.
-- Reforçar testes de fluxo essencial (create/update/delete) conforme regras atuais de permissão.
-- Executar o change em slices com TDD (RED/GREEN/REFACTOR).
+
+- garantir que o form persista a descrição canônica do evento
+  (`HISTORY_AND_PHYSICAL_EVENT`)
+- eliminar side effect de debug em inicialização de formulário
+- reforçar testes de fluxo essencial (create/update/delete) conforme regras
+  atuais de permissão
+- executar o change em slices com TDD (RED/GREEN/REFACTOR)
 
 **Non-Goals**
-- Não reescrever arquitetura de views do app.
-- Não alterar política global de permissões do projeto.
-- Não introduzir novas features de produto.
+
+- não reescrever arquitetura de views do app
+- não alterar política global de permissões do projeto
+- não introduzir novas features de produto
 
 ## Decisions
 
-1) **Descrição canônica no form**
-- **Decision:** manter e garantir a regra de descrição no `HistoryAndPhysicalForm.save()`.
-- **Rationale:** centraliza comportamento no ponto de persistência e reduz divergência entre views.
+1. **Descrição canônica no form**
 
-2) **Sem debug stdout em produção/testes**
-- **Decision:** remover `print` do `__init__` do form.
-- **Rationale:** evitar ruído e side effects em testes/CI.
+   - **Decision:** manter e garantir a regra de descrição no
+     `HistoryAndPhysicalForm.save()`
+   - **Rationale:** centraliza comportamento no ponto de persistência e reduz
+     divergência entre views
 
-3) **Cobertura de testes por risco real**
-- **Decision:** priorizar testes de create/update/delete e cenários mínimos de permissão.
-- **Rationale:** maior retorno com baixo risco na semana 2.
+1. **Sem debug stdout em produção/testes**
+
+   - **Decision:** remover `print` do `__init__` do form
+   - **Rationale:** evitar ruído e side effects em testes/CI
+
+1. **Cobertura de testes por risco real**
+
+   - **Decision:** priorizar testes de create/update/delete e cenários mínimos
+     de permissão
+   - **Rationale:** maior retorno com baixo risco na semana 2
 
 ## Risks / Trade-offs
 
-- **[Testes podem depender de comportamentos legados implícitos]** → Mitigação: explicitar expectativas com asserts diretos.
-- **[Escopo pode crescer para refator amplo]** → Mitigação: limitar mudanças aos arquivos do slice.
+- **[Testes podem depender de comportamentos legados implícitos]**
+  Mitigação: explicitar expectativas com asserts diretos.
+- **[Escopo pode crescer para refator amplo]**
+  Mitigação: limitar mudanças aos arquivos do slice.
 
 ## Verification Plan
 
@@ -43,5 +57,5 @@ Objetivo: fortalecer previsibilidade de comportamento no form e aumentar cobertu
 
 ## Rollback Plan
 
-- Reverter commits do change.
-- Reexecutar testes do app + typecheck escopado para confirmar restauração.
+- reverter commits do change
+- reexecutar testes do app + typecheck escopado para confirmar restauração

--- a/openspec/changes/week2-historyandphysicals-hardening/proposal.md
+++ b/openspec/changes/week2-historyandphysicals-hardening/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Após o piloto da semana 1 em `simplenotes`, o próximo passo natural é repetir o mesmo padrão em outro app de baixo risco para consolidar o workflow DevLoop.
+
+`historyandphysicals` apresenta sinais semelhantes ao que foi tratado no piloto:
+- side effect de debug no form (`print` em `__init__`)
+- atribuição de descrição canônica potencialmente incorreta no `save()` do form
+- necessidade de reforço de testes de fluxo essencial sem ampliar escopo
+
+## What Changes
+
+- Harden do `HistoryAndPhysicalForm` para garantir persistência canônica de descrição.
+- Remoção de debug output no form.
+- Ampliação/ajuste de testes no fluxo essencial (create/update/delete) com foco em regras atuais.
+- Execução por slices curtos com TDD e stop rule.
+
+## Capabilities
+
+### New Capabilities
+- Nenhuma nova capacidade funcional para usuário final.
+
+### Modified Capabilities
+- `historyandphysicals`: maior estabilidade de comportamento no form e maior segurança de regressão no CRUD essencial.
+
+## Impact
+
+- Escopo concentrado em `apps/historyandphysicals` + artefatos OpenSpec.
+- Sem migração de banco.
+- Sem alteração de contrato externo.

--- a/openspec/changes/week2-historyandphysicals-hardening/proposal.md
+++ b/openspec/changes/week2-historyandphysicals-hardening/proposal.md
@@ -1,29 +1,36 @@
 ## Why
 
-Após o piloto da semana 1 em `simplenotes`, o próximo passo natural é repetir o mesmo padrão em outro app de baixo risco para consolidar o workflow DevLoop.
+Após o piloto da semana 1 em `simplenotes`, o próximo passo natural é repetir
+o mesmo padrão em outro app de baixo risco para consolidar o workflow DevLoop.
 
 `historyandphysicals` apresenta sinais semelhantes ao que foi tratado no piloto:
+
 - side effect de debug no form (`print` em `__init__`)
 - atribuição de descrição canônica potencialmente incorreta no `save()` do form
 - necessidade de reforço de testes de fluxo essencial sem ampliar escopo
 
 ## What Changes
 
-- Harden do `HistoryAndPhysicalForm` para garantir persistência canônica de descrição.
-- Remoção de debug output no form.
-- Ampliação/ajuste de testes no fluxo essencial (create/update/delete) com foco em regras atuais.
-- Execução por slices curtos com TDD e stop rule.
+- hardening do `HistoryAndPhysicalForm` para garantir persistência canônica de
+  descrição
+- remoção de debug output no form
+- ampliação/ajuste de testes no fluxo essencial (create/update/delete), com
+  foco nas regras atuais
+- execução por slices curtos com TDD e stop rule
 
 ## Capabilities
 
 ### New Capabilities
-- Nenhuma nova capacidade funcional para usuário final.
+
+- nenhuma nova capacidade funcional para usuário final
 
 ### Modified Capabilities
-- `historyandphysicals`: maior estabilidade de comportamento no form e maior segurança de regressão no CRUD essencial.
+
+- `historyandphysicals`: maior estabilidade de comportamento no form e maior
+  segurança de regressão no CRUD essencial
 
 ## Impact
 
-- Escopo concentrado em `apps/historyandphysicals` + artefatos OpenSpec.
-- Sem migração de banco.
-- Sem alteração de contrato externo.
+- escopo concentrado em `apps/historyandphysicals` + artefatos OpenSpec
+- sem migração de banco
+- sem alteração de contrato externo

--- a/openspec/changes/week2-historyandphysicals-hardening/slices/slice-01-prompt.md
+++ b/openspec/changes/week2-historyandphysicals-hardening/slices/slice-01-prompt.md
@@ -1,0 +1,30 @@
+Execute ONLY Slice 01 as described in slice-01.md.
+
+Rules:
+- Follow TDD strictly (RED -> GREEN -> REFACTOR).
+- Touch only listed files.
+- Stop after slice completion.
+
+Checklist:
+Spec
+- [ ] requirements understood
+
+Tests (RED)
+- [ ] failing tests written
+- [ ] tests cover behavior and edge cases
+
+Implementation (GREEN)
+- [ ] minimal code added
+- [ ] tests pass
+
+Refactor (CLEAN)
+- [ ] responsibilities separated
+- [ ] duplication removed
+- [ ] functions small
+- [ ] naming improved
+
+Verification
+- [ ] verification command passes
+
+STOP RULE
+- [ ] stop here and do NOT start next slice

--- a/openspec/changes/week2-historyandphysicals-hardening/slices/slice-01-prompt.md
+++ b/openspec/changes/week2-historyandphysicals-hardening/slices/slice-01-prompt.md
@@ -1,30 +1,38 @@
-Execute ONLY Slice 01 as described in slice-01.md.
+Execute ONLY Slice 01 as described in `slice-01.md`.
 
-Rules:
+## Rules
+
 - Follow TDD strictly (RED -> GREEN -> REFACTOR).
 - Touch only listed files.
 - Stop after slice completion.
 
-Checklist:
-Spec
+## Checklist
+
+### Spec
+
 - [ ] requirements understood
 
-Tests (RED)
+### Tests (RED)
+
 - [ ] failing tests written
 - [ ] tests cover behavior and edge cases
 
-Implementation (GREEN)
+### Implementation (GREEN)
+
 - [ ] minimal code added
 - [ ] tests pass
 
-Refactor (CLEAN)
+### Refactor (CLEAN)
+
 - [ ] responsibilities separated
 - [ ] duplication removed
 - [ ] functions small
 - [ ] naming improved
 
-Verification
+### Verification
+
 - [ ] verification command passes
 
-STOP RULE
+### STOP RULE
+
 - [ ] stop here and do NOT start next slice

--- a/openspec/changes/week2-historyandphysicals-hardening/slices/slice-01.md
+++ b/openspec/changes/week2-historyandphysicals-hardening/slices/slice-01.md
@@ -1,0 +1,24 @@
+# Slice 01 - HistoryAndPhysicalForm hardening
+
+Goal:
+Corrigir persistência de descrição canônica e remover side effect de debug no form.
+
+Scope boundaries:
+- Included: `HistoryAndPhysicalForm` + testes de form/model relacionados.
+- Excluded: refator amplo de views/templates.
+
+Files to create/modify:
+- apps/historyandphysicals/forms.py
+- apps/historyandphysicals/tests/test_models_forms.py
+
+Tests to write FIRST (TDD):
+- test_form_save_sets_canonical_description
+- test_form_init_has_no_debug_stdout
+
+Implementation steps:
+1) Garantir `instance.description` canônica no `save()` do form.
+2) Remover `print` no `__init__`.
+3) Ajustar testes para cobrir comportamento esperado.
+
+Verification commands:
+- ./scripts/test.sh apps.historyandphysicals.tests.test_models_forms

--- a/openspec/changes/week2-historyandphysicals-hardening/slices/slice-01.md
+++ b/openspec/changes/week2-historyandphysicals-hardening/slices/slice-01.md
@@ -1,24 +1,31 @@
 # Slice 01 - HistoryAndPhysicalForm hardening
 
-Goal:
-Corrigir persistência de descrição canônica e remover side effect de debug no form.
+## Goal
 
-Scope boundaries:
-- Included: `HistoryAndPhysicalForm` + testes de form/model relacionados.
-- Excluded: refator amplo de views/templates.
+Corrigir persistência de descrição canônica e remover side effect de debug no
+form.
 
-Files to create/modify:
-- apps/historyandphysicals/forms.py
-- apps/historyandphysicals/tests/test_models_forms.py
+## Scope boundaries
 
-Tests to write FIRST (TDD):
-- test_form_save_sets_canonical_description
-- test_form_init_has_no_debug_stdout
+- Included: `HistoryAndPhysicalForm` + testes de form/model relacionados
+- Excluded: refator amplo de views/templates
 
-Implementation steps:
-1) Garantir `instance.description` canônica no `save()` do form.
-2) Remover `print` no `__init__`.
-3) Ajustar testes para cobrir comportamento esperado.
+## Files to create/modify
 
-Verification commands:
-- ./scripts/test.sh apps.historyandphysicals.tests.test_models_forms
+- `apps/historyandphysicals/forms.py`
+- `apps/historyandphysicals/tests/test_models_forms.py`
+
+## Tests to write FIRST (TDD)
+
+- `test_form_save_sets_canonical_description`
+- `test_form_init_has_no_debug_stdout`
+
+## Implementation steps
+
+1. Garantir `instance.description` canônica no `save()` do form.
+1. Remover `print` no `__init__`.
+1. Ajustar testes para cobrir comportamento esperado.
+
+## Verification commands
+
+- `./scripts/test.sh apps.historyandphysicals.tests.test_models_forms`

--- a/openspec/changes/week2-historyandphysicals-hardening/slices/slice-02-prompt.md
+++ b/openspec/changes/week2-historyandphysicals-hardening/slices/slice-02-prompt.md
@@ -1,0 +1,30 @@
+Execute ONLY Slice 02 as described in slice-02.md.
+
+Rules:
+- Follow TDD strictly (RED -> GREEN -> REFACTOR).
+- Stay inside listed files and scope.
+- Stop after completion.
+
+Checklist:
+Spec
+- [ ] requirements understood
+
+Tests (RED)
+- [ ] failing tests written
+- [ ] tests cover behavior and edge cases
+
+Implementation (GREEN)
+- [ ] minimal code added
+- [ ] tests pass
+
+Refactor (CLEAN)
+- [ ] responsibilities separated
+- [ ] duplication removed
+- [ ] functions small
+- [ ] naming improved
+
+Verification
+- [ ] verification command passes
+
+STOP RULE
+- [ ] stop here and do NOT start next slice

--- a/openspec/changes/week2-historyandphysicals-hardening/slices/slice-02-prompt.md
+++ b/openspec/changes/week2-historyandphysicals-hardening/slices/slice-02-prompt.md
@@ -1,30 +1,38 @@
-Execute ONLY Slice 02 as described in slice-02.md.
+Execute ONLY Slice 02 as described in `slice-02.md`.
 
-Rules:
+## Rules
+
 - Follow TDD strictly (RED -> GREEN -> REFACTOR).
 - Stay inside listed files and scope.
 - Stop after completion.
 
-Checklist:
-Spec
+## Checklist
+
+### Spec
+
 - [ ] requirements understood
 
-Tests (RED)
+### Tests (RED)
+
 - [ ] failing tests written
 - [ ] tests cover behavior and edge cases
 
-Implementation (GREEN)
+### Implementation (GREEN)
+
 - [ ] minimal code added
 - [ ] tests pass
 
-Refactor (CLEAN)
+### Refactor (CLEAN)
+
 - [ ] responsibilities separated
 - [ ] duplication removed
 - [ ] functions small
 - [ ] naming improved
 
-Verification
+### Verification
+
 - [ ] verification command passes
 
-STOP RULE
+### STOP RULE
+
 - [ ] stop here and do NOT start next slice

--- a/openspec/changes/week2-historyandphysicals-hardening/slices/slice-02.md
+++ b/openspec/changes/week2-historyandphysicals-hardening/slices/slice-02.md
@@ -1,0 +1,24 @@
+# Slice 02 - CRUD safety net mínimo de views
+
+Goal:
+Reforçar cobertura de create/update/delete essencial com foco em risco baixo.
+
+Scope boundaries:
+- Included: testes de integração/views do app.
+- Excluded: mudanças funcionais fora do escopo do app.
+
+Files to create/modify:
+- apps/historyandphysicals/tests/test_integration.py
+- apps/historyandphysicals/tests/test_permissions.py (se necessário)
+
+Tests to write FIRST (TDD):
+- test_create_historyandphysical_for_accessible_patient
+- test_update_historyandphysical_allowed_for_creator_within_window
+- test_delete_historyandphysical_denied_when_permission_fails
+
+Implementation steps:
+1) Adicionar/ajustar testes para fluxo essencial.
+2) Ajustar implementação apenas se necessário para atender comportamento esperado.
+
+Verification commands:
+- ./scripts/test.sh apps.historyandphysicals

--- a/openspec/changes/week2-historyandphysicals-hardening/slices/slice-02.md
+++ b/openspec/changes/week2-historyandphysicals-hardening/slices/slice-02.md
@@ -1,24 +1,31 @@
 # Slice 02 - CRUD safety net mínimo de views
 
-Goal:
+## Goal
+
 Reforçar cobertura de create/update/delete essencial com foco em risco baixo.
 
-Scope boundaries:
-- Included: testes de integração/views do app.
-- Excluded: mudanças funcionais fora do escopo do app.
+## Scope boundaries
 
-Files to create/modify:
-- apps/historyandphysicals/tests/test_integration.py
-- apps/historyandphysicals/tests/test_permissions.py (se necessário)
+- Included: testes de integração/views do app
+- Excluded: mudanças funcionais fora do escopo do app
 
-Tests to write FIRST (TDD):
-- test_create_historyandphysical_for_accessible_patient
-- test_update_historyandphysical_allowed_for_creator_within_window
-- test_delete_historyandphysical_denied_when_permission_fails
+## Files to create/modify
 
-Implementation steps:
-1) Adicionar/ajustar testes para fluxo essencial.
-2) Ajustar implementação apenas se necessário para atender comportamento esperado.
+- `apps/historyandphysicals/tests/test_integration.py`
+- `apps/historyandphysicals/tests/test_permissions.py` (se necessário)
 
-Verification commands:
-- ./scripts/test.sh apps.historyandphysicals
+## Tests to write FIRST (TDD)
+
+- `test_create_historyandphysical_for_accessible_patient`
+- `test_update_historyandphysical_allowed_for_creator_within_window`
+- `test_delete_historyandphysical_denied_when_permission_fails`
+
+## Implementation steps
+
+1. Adicionar/ajustar testes para fluxo essencial.
+1. Ajustar implementação apenas se necessário para atender comportamento
+   esperado.
+
+## Verification commands
+
+- `./scripts/test.sh apps.historyandphysicals`

--- a/openspec/changes/week2-historyandphysicals-hardening/slices/slice-03-prompt.md
+++ b/openspec/changes/week2-historyandphysicals-hardening/slices/slice-03-prompt.md
@@ -1,21 +1,27 @@
-Execute ONLY Slice 03 as described in slice-03.md.
+Execute ONLY Slice 03 as described in `slice-03.md`.
 
-Rules:
+## Rules
+
 - Do not introduce new features.
 - Focus on validation + evidence + OpenSpec updates.
 - Stop after completion.
 
-Checklist:
-Spec
+## Checklist
+
+### Spec
+
 - [ ] requirements understood
 
-Execution
+### Execution
+
 - [ ] validation commands executed
 - [ ] progress log updated
 - [ ] OpenSpec tasks updated
 
-Verification
+### Verification
+
 - [ ] verification commands pass
 
-STOP RULE
+### STOP RULE
+
 - [ ] stop here and do NOT start next slice

--- a/openspec/changes/week2-historyandphysicals-hardening/slices/slice-03-prompt.md
+++ b/openspec/changes/week2-historyandphysicals-hardening/slices/slice-03-prompt.md
@@ -1,0 +1,21 @@
+Execute ONLY Slice 03 as described in slice-03.md.
+
+Rules:
+- Do not introduce new features.
+- Focus on validation + evidence + OpenSpec updates.
+- Stop after completion.
+
+Checklist:
+Spec
+- [ ] requirements understood
+
+Execution
+- [ ] validation commands executed
+- [ ] progress log updated
+- [ ] OpenSpec tasks updated
+
+Verification
+- [ ] verification commands pass
+
+STOP RULE
+- [ ] stop here and do NOT start next slice

--- a/openspec/changes/week2-historyandphysicals-hardening/slices/slice-03.md
+++ b/openspec/changes/week2-historyandphysicals-hardening/slices/slice-03.md
@@ -1,0 +1,22 @@
+# Slice 03 - Fechamento da semana 2
+
+Goal:
+Fechar o change com validação final e evidências atualizadas.
+
+Scope boundaries:
+- Included: validação final, atualização de log e tasks.
+- Excluded: novas features.
+
+Files to create/modify:
+- docs/workflows/devloop-migration/progress-log.md
+- openspec/changes/week2-historyandphysicals-hardening/tasks.md
+- openspec/changes/week2-historyandphysicals-hardening/slices/slice-03-prompt.md
+
+Implementation steps:
+1) Rodar validações finais do app.
+2) Atualizar evidências no progress log.
+3) Marcar tasks concluídas e preparar sync/archive.
+
+Verification commands:
+- ./scripts/test.sh apps.historyandphysicals
+- ./scripts/typecheck.sh apps/historyandphysicals

--- a/openspec/changes/week2-historyandphysicals-hardening/slices/slice-03.md
+++ b/openspec/changes/week2-historyandphysicals-hardening/slices/slice-03.md
@@ -1,22 +1,27 @@
 # Slice 03 - Fechamento da semana 2
 
-Goal:
+## Goal
+
 Fechar o change com validação final e evidências atualizadas.
 
-Scope boundaries:
-- Included: validação final, atualização de log e tasks.
-- Excluded: novas features.
+## Scope boundaries
 
-Files to create/modify:
-- docs/workflows/devloop-migration/progress-log.md
-- openspec/changes/week2-historyandphysicals-hardening/tasks.md
-- openspec/changes/week2-historyandphysicals-hardening/slices/slice-03-prompt.md
+- Included: validação final, atualização de log e tasks
+- Excluded: novas features
 
-Implementation steps:
-1) Rodar validações finais do app.
-2) Atualizar evidências no progress log.
-3) Marcar tasks concluídas e preparar sync/archive.
+## Files to create/modify
 
-Verification commands:
-- ./scripts/test.sh apps.historyandphysicals
-- ./scripts/typecheck.sh apps/historyandphysicals
+- `docs/workflows/devloop-migration/progress-log.md`
+- `openspec/changes/week2-historyandphysicals-hardening/tasks.md`
+- `openspec/changes/week2-historyandphysicals-hardening/slices/slice-03-prompt.md`
+
+## Implementation steps
+
+1. Rodar validações finais do app.
+1. Atualizar evidências no progress log.
+1. Marcar tasks concluídas e preparar sync/archive.
+
+## Verification commands
+
+- `./scripts/test.sh apps.historyandphysicals`
+- `./scripts/typecheck.sh apps/historyandphysicals`

--- a/openspec/changes/week2-historyandphysicals-hardening/specs/historyandphysicals/spec.md
+++ b/openspec/changes/week2-historyandphysicals-hardening/specs/historyandphysicals/spec.md
@@ -1,30 +1,43 @@
 ## MODIFIED Requirements
 
 ### Requirement: HistoryAndPhysical form MUST persist canonical event description
-The system SHALL persist canonical event description for `HistoryAndPhysical` when saving through `HistoryAndPhysicalForm`, without relying on view-level manual assignment.
+
+The system SHALL persist canonical event description for `HistoryAndPhysical`
+when saving through `HistoryAndPhysicalForm`, without relying on view-level
+manual assignment.
 
 #### Scenario: Form save sets canonical description
+
 - **WHEN** a valid `HistoryAndPhysicalForm` is saved
-- **THEN** the resulting event description matches the canonical label for `HISTORY_AND_PHYSICAL_EVENT`
+- **THEN** the resulting event description matches the canonical label for
+  `HISTORY_AND_PHYSICAL_EVENT`
 
 #### Scenario: Form save keeps audit ownership
+
 - **WHEN** `HistoryAndPhysicalForm` receives `user` and saves a new instance
 - **THEN** `created_by` and `updated_by` are set to the current user
 
 ### Requirement: HistoryAndPhysical form MUST avoid debug stdout side effects
-The system SHALL NOT emit debug `print` output during normal form initialization.
+
+The system SHALL NOT emit debug `print` output during normal form
+initialization.
 
 #### Scenario: Form initialization has no stdout debug output
+
 - **WHEN** `HistoryAndPhysicalForm` is instantiated
 - **THEN** no debug output is written to stdout
 
 ### Requirement: Essential HistoryAndPhysical CRUD flow MUST remain covered by tests
-The project SHALL maintain automated coverage for essential create/update/delete flow and current permission expectations.
+
+The project SHALL maintain automated coverage for essential create/update/delete
+flow and current permission expectations.
 
 #### Scenario: Create flow is covered
+
 - **WHEN** a valid create request is submitted for accessible patient
 - **THEN** tests confirm successful persistence and redirect behavior
 
 #### Scenario: Permission denial path is covered
+
 - **WHEN** a non-authorized user accesses protected update/delete path
 - **THEN** tests confirm deny behavior under current rules

--- a/openspec/changes/week2-historyandphysicals-hardening/specs/historyandphysicals/spec.md
+++ b/openspec/changes/week2-historyandphysicals-hardening/specs/historyandphysicals/spec.md
@@ -1,0 +1,30 @@
+## MODIFIED Requirements
+
+### Requirement: HistoryAndPhysical form MUST persist canonical event description
+The system SHALL persist canonical event description for `HistoryAndPhysical` when saving through `HistoryAndPhysicalForm`, without relying on view-level manual assignment.
+
+#### Scenario: Form save sets canonical description
+- **WHEN** a valid `HistoryAndPhysicalForm` is saved
+- **THEN** the resulting event description matches the canonical label for `HISTORY_AND_PHYSICAL_EVENT`
+
+#### Scenario: Form save keeps audit ownership
+- **WHEN** `HistoryAndPhysicalForm` receives `user` and saves a new instance
+- **THEN** `created_by` and `updated_by` are set to the current user
+
+### Requirement: HistoryAndPhysical form MUST avoid debug stdout side effects
+The system SHALL NOT emit debug `print` output during normal form initialization.
+
+#### Scenario: Form initialization has no stdout debug output
+- **WHEN** `HistoryAndPhysicalForm` is instantiated
+- **THEN** no debug output is written to stdout
+
+### Requirement: Essential HistoryAndPhysical CRUD flow MUST remain covered by tests
+The project SHALL maintain automated coverage for essential create/update/delete flow and current permission expectations.
+
+#### Scenario: Create flow is covered
+- **WHEN** a valid create request is submitted for accessible patient
+- **THEN** tests confirm successful persistence and redirect behavior
+
+#### Scenario: Permission denial path is covered
+- **WHEN** a non-authorized user accesses protected update/delete path
+- **THEN** tests confirm deny behavior under current rules

--- a/openspec/changes/week2-historyandphysicals-hardening/tasks.md
+++ b/openspec/changes/week2-historyandphysicals-hardening/tasks.md
@@ -1,0 +1,25 @@
+## 1. Preparação
+
+- [ ] 1.1 Confirmar escopo do change (sem scope creep)
+- [ ] 1.2 Confirmar arquivos do slice 1
+- [ ] 1.3 Confirmar comandos de validação do app
+
+## 2. Slice 1 — Form hardening
+
+- [ ] 2.1 Escrever testes RED para descrição canônica no `HistoryAndPhysicalForm.save()`
+- [ ] 2.2 Corrigir persistência da descrição canônica
+- [ ] 2.3 Remover debug `print` do form
+- [ ] 2.4 Validar `./scripts/test.sh apps.historyandphysicals.tests.test_models_forms`
+
+## 3. Slice 2 — CRUD safety net mínimo
+
+- [ ] 3.1 Adicionar/ajustar testes de views para create/update/delete essenciais
+- [ ] 3.2 Cobrir cenário mínimo de permissão negada
+- [ ] 3.3 Validar `./scripts/test.sh apps.historyandphysicals`
+
+## 4. Slice 3 — Fechamento da semana 2
+
+- [ ] 4.1 Rodar `./scripts/typecheck.sh apps/historyandphysicals`
+- [ ] 4.2 Atualizar `docs/workflows/devloop-migration/progress-log.md`
+- [ ] 4.3 Registrar evidências do change no PR
+- [ ] 4.4 Sincronizar/arquivar change OpenSpec ao concluir


### PR DESCRIPTION
## Contexto
Abre o change OpenSpec da semana 2 para evolução incremental do app `historyandphysicals`, seguindo o mesmo padrão do piloto da semana 1.

## O que foi adicionado
- `proposal.md`, `design.md`, `tasks.md`
- `specs/historyandphysicals/spec.md`
- slices 01–03 com prompts
- atualização do `progress-log.md` com referência ao novo change

## Escopo
Somente artefatos de planejamento/OpenSpec. Sem mudança funcional de código da aplicação.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive planning and specification documentation for an upcoming development initiative, including architectural design, detailed implementation plan, test-driven development specifications, and structured task breakdown across three execution phases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->